### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The `go-wordpressxml` package provides WordPress XML parser.
 
 ## Documentation
 
-Documentation is provided using godoc and available on [GoDoc.org](https://godoc.org/github.com/grokify/go0wordpressxml).
+Documentation is provided using godoc and available on [GoDoc.org](https://godoc.org/github.com/grokify/go-wordpressxml).
 
 ## Installation
 


### PR DESCRIPTION
Fixed the link to the go docs from 

https://godoc.org/github.com/grokify/go0wordpressxml 

to 
https://godoc.org/github.com/grokify/go-wordpressxml